### PR TITLE
生成されるファイルのフォーマットを最新のコーディング規約に合わせて修正する

### DIFF
--- a/templates/bake/Model/entity.twig
+++ b/templates/bake/Model/entity.twig
@@ -24,6 +24,7 @@
 
 {%- set accessible = Bake.getFieldAccessibility(fields, primaryKey) %}
 <?php
+
 declare(strict_types=1);
 
 namespace {{ namespace }}\Model\Baked\Entity;

--- a/templates/bake/Model/extended_entity.twig
+++ b/templates/bake/Model/extended_entity.twig
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace {{ namespace }}\Model\Entity;

--- a/templates/bake/Model/extended_table.twig
+++ b/templates/bake/Model/extended_table.twig
@@ -5,8 +5,7 @@ declare(strict_types=1);
 namespace {{ namespace }}\Model\Table;
 
 use {{ namespace }}\Model\Baked\Table\{{ name }}Table as BakedTable;
-
-{% set uses = ['use Cake\\ORM\\Query;', 'use Cake\\ORM\\RulesChecker;', 'use Cake\\ORM\\Table;', 'use Cake\\Validation\\Validator;'] %}
+{% set uses = ['use Cake\\ORM\\RulesChecker;','use Cake\\Validation\\Validator;'] %}
 {{ uses|join('\n')|raw }}
 
 /**

--- a/templates/bake/Model/extended_table.twig
+++ b/templates/bake/Model/extended_table.twig
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace {{ namespace }}\Model\Table;

--- a/templates/bake/Model/table.twig
+++ b/templates/bake/Model/table.twig
@@ -15,16 +15,15 @@
 #}
 {% set annotations = DocBlock.buildTableAnnotations(associations, associationInfo, behaviors, entity, namespace) %}
 <?php
+
 declare(strict_types=1);
 
 namespace {{ namespace }}\Model\Baked\Table;
 
 {% set uses = [
-        'use Cake\\ORM\\Query;',
-        'use Cake\\ORM\\RulesChecker;',
-        'use Cake\\ORM\\Table;',
-        'use Cake\\Validation\\Validator;',
         'use App\\Model\\Table\\BaseTable;',
+        'use Cake\\ORM\\RulesChecker;',
+        'use Cake\\Validation\\Validator;',
     ] %}
 {{ uses|join('\n')|raw }}
 

--- a/tests/TestCase/Command/ExtendedModelCommandTest.php
+++ b/tests/TestCase/Command/ExtendedModelCommandTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace GenerationGapModelBaker\Test\TestCase\Command;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**


### PR DESCRIPTION
## 実装の目的/背景
#6 のissueに基づき、コーディングチェックに引っ掛かるようになった箇所を修正しました

## テスト証跡

lancers_admin内でブランチを切り
```
bin/cake bake extended_model payments
```
コマンドを実行し、今回の修正で引っ掛からなくなることを確認

※TestCaseの自動生成ファイルはあらかじめ削除しました

- 修正前
<img src="https://user-images.githubusercontent.com/62461866/144418406-d30ba265-2682-473f-8d84-4e753f212d65.png">

- 修正後　（コマンド整形のslack通知が来ないことを確認）
<img src="https://user-images.githubusercontent.com/62461866/144418433-daabcf7c-60f7-445e-9fbe-3f5ff6f8b55c.png">
